### PR TITLE
snapd: fix generation of systemd unit files, use /etc/default/snapd as environment file

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = snapd
 	pkgdesc = Service and tools for management of snap packages.
 	pkgver = 2.30
-	pkgrel = 8
+	pkgrel = 9
 	url = https://github.com/snapcore/snapd
 	install = snapd.install
 	arch = i686

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -7,7 +7,7 @@ pkgname=snapd
 pkgdesc="Service and tools for management of snap packages."
 depends=('squashfs-tools' 'libseccomp' 'libsystemd')
 pkgver=2.30
-pkgrel=8
+pkgrel=9
 arch=('i686' 'x86_64' 'armv7h' 'aarch64')
 url="https://github.com/snapcore/snapd"
 license=('GPL3')
@@ -61,8 +61,9 @@ build() {
   CGO_ENABLED=0 go build -o $GOPATH/bin/snap-exec "${_gourl}/cmd/snap-exec"
 
   # Generate the real systemd units out of the available templates
-  make -C data/systemd
-    SNAP_MOUNT_DIR=/var/lib/snapd/snap
+  make -C data/systemd \
+    SNAP_MOUNT_DIR=/var/lib/snapd/snap \
+    SNAPD_ENVIRONMENT_FILE=/etc/default/snapd
 
   cd cmd
   autoreconf -i -f


### PR DESCRIPTION
@aimileus @zyga please review this change for snapd AUR package.

This will unify snapd.service environment file accross snapd (which defaults to /etc/environment) and snapd-git (using /etc/default/snapd). Also, the `make -C data/systemd..` is fixed. Missing `\` resulted in default settings being used while generating the unit files. Fortunately the stuff didn't break and as  far as I can tell the only downside was that `snapd.refresh.service` ended up having `ConditionPathExists=/snap/*/current` instead of `ConditionPathExists=/var/lib/snapd/snap/*/current`