### PR TITLE
snapd: create /var/lib/snapd/lib/{gl32,vulkan}, remove redundant rules, pass SNAP_MOUNT_DIR

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = snapd
 	pkgdesc = Service and tools for management of snap packages.
 	pkgver = 2.30
-	pkgrel = 9
+	pkgrel = 10
 	url = https://github.com/snapcore/snapd
 	install = snapd.install
 	arch = i686

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -7,7 +7,7 @@ pkgname=snapd
 pkgdesc="Service and tools for management of snap packages."
 depends=('squashfs-tools' 'libseccomp' 'libsystemd')
 pkgver=2.30
-pkgrel=9
+pkgrel=10
 arch=('i686' 'x86_64' 'armv7h' 'aarch64')
 url="https://github.com/snapcore/snapd"
 license=('GPL3')
@@ -80,9 +80,6 @@ build() {
 
 package() {
   export GOPATH="$srcdir/go"
-  # Ensure that we have /var/lib/snapd/{hostfs,lib/gl}/ as they are required
-  # by snap-confine for constructing some bind mounts around.
-  install -dm755 "$pkgdir/var/lib/snapd/hostfs/" "$pkgdir/var/lib/snapd/lib/gl/"
 
   # Install bash completion
   install -Dm644 "$srcdir/$pkgname/data/completion/snap" \
@@ -97,6 +94,7 @@ package() {
      DBUSSERVICESDIR=/usr/share/dbus-1/services \
      BINDIR=/usr/bin \
      SYSTEMDSYSTEMUNITDIR=/usr/lib/systemd/system \
+     SNAP_MOUNT_DIR=/var/lib/snapd/snap \
      DESTDIR="$pkgdir"
 
   # Install polkit policy
@@ -127,6 +125,8 @@ package() {
   install -dm755 "$pkgdir/var/lib/snapd/snap/bin"
   install -dm755 "$pkgdir/var/lib/snapd/snaps"
   install -dm755 "$pkgdir/var/lib/snapd/lib/gl"
+  install -dm755 "$pkgdir/var/lib/snapd/lib/gl32"
+  install -dm755 "$pkgdir/var/lib/snapd/lib/vulkan"
   install -dm000 "$pkgdir/var/lib/snapd/void"
   install -dm700 "$pkgdir/var/lib/snapd/cookie"
   install -dm700 "$pkgdir/var/lib/snapd/cache"


### PR DESCRIPTION
Couple of updates:

- pre-create /var/lib/snapd/lib/{gl32,vulkan}

  Both are needed when setting importing the files into the mount namespace in
  snap-confine. Although the code will create both dirs automatically, it's
  better to have them created explicitly

- cleanup redundant rules

  Both /var/lib/snapd/{hostfs,lib/gl} are created later on with the rest of
  /var/lib/snapd directories

- pass SNAP_MOUNT_DIR to make install

  This will break when we update to 2.31 due to a new snap.mount systemd unit.

@aimileus @zyga 