### PR TITLE
snapd: use budled release pacakage, bump to 2.33-2

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = snapd
 	pkgdesc = Service and tools for management of snap packages.
 	pkgver = 2.33
-	pkgrel = 1
+	pkgrel = 2
 	url = https://github.com/snapcore/snapd
 	install = snapd.install
 	arch = x86_64
@@ -21,8 +21,8 @@ pkgbase = snapd
 	conflicts = snap-confine
 	options = !strip
 	options = emptydirs
-	source = snapd-2.33.tar.gz::https://github.com/snapcore/snapd/archive/2.33.tar.gz
-	sha256sums = 7d75bb3589086381aec6f6039f1dddcadd79d35e3a544b32701e86636baa97c2
+	source = snapd-2.33.tar.xz::https://github.com/snapcore/snapd/releases/download/2.33/snapd_2.33.vendor.tar.xz
+	sha256sums = 35f429194398461e74e13aaec47307754adcafc1571044d625fcf561537c103c
 
 pkgname = snapd
 

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -8,7 +8,7 @@ pkgdesc="Service and tools for management of snap packages."
 depends=('squashfs-tools' 'libseccomp' 'libsystemd')
 optdepends=('bash-completion: bash completion support')
 pkgver=2.33
-pkgrel=1
+pkgrel=2
 arch=('x86_64')
 url="https://github.com/snapcore/snapd"
 license=('GPL3')
@@ -16,8 +16,8 @@ makedepends=('git' 'go' 'go-tools' 'libseccomp' 'libcap' 'systemd' 'xfsprogs' 'p
 conflicts=('snap-confine')
 options=('!strip' 'emptydirs')
 install=snapd.install
-source=("$pkgname-$pkgver.tar.gz::https://github.com/snapcore/${pkgname}/archive/$pkgver.tar.gz")
-sha256sums=('7d75bb3589086381aec6f6039f1dddcadd79d35e3a544b32701e86636baa97c2')
+source=("$pkgname-$pkgver.tar.xz::https://github.com/snapcore/${pkgname}/releases/download/${pkgver}/${pkgname}_${pkgver}.vendor.tar.xz")
+sha256sums=('35f429194398461e74e13aaec47307754adcafc1571044d625fcf561537c103c')
 
 _gourl=github.com/snapcore/snapd
 
@@ -45,11 +45,6 @@ build() {
   export CGO_LDFLAGS="${LDFLAGS}"
 
   ./mkversion.sh $pkgver-$pkgrel
-
-  # Use get-deps.sh provided by upstream to fetch go dependencies using the
-  # godeps tool and dependencies.tsv (maintained upstream).
-  cd "$GOPATH/src/${_gourl}"
-  XDG_CONFIG_HOME="$srcdir" ./get-deps.sh
 
   gobuild="go build -buildmode=pie"
   gobuild_static="go build -buildmode=pie -ldflags=-extldflags=-static"


### PR DESCRIPTION
Users have reported issues with govendor trying to get the dependencies. Avoid
this by using the source tarball with bundled vendor dependencies.

Additionally, this will speed up the package build process significantly.

@aimileus @zyga 